### PR TITLE
Makefile: add a missing paren

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ifneq ($(wildcard .gitmodules),)
 endif
 ifneq ($(wildcard data),)
 	(cd data && git pull)
-	(cd data && git submodule update --init --recursive
+	(cd data && git submodule update --init --recursive)
 	(cd data && git submodule foreach "(git checkout master; git pull origin master)")
 endif
 ifneq ($(wildcard humextra/external/improv),)


### PR DESCRIPTION
This doesn't have any real effect other than emitting a warning that I happened to notice.